### PR TITLE
Echo Framework Name

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# Nothing to detect, just agree
+echo "jq"
 exit 0


### PR DESCRIPTION
The current version of the [buildpack documentation](https://devcenter.heroku.com/articles/buildpack-api#bin-detect-summary) states:

>  If the exit code is 0, the script must print a human-readable framework name to stdout.
